### PR TITLE
Launch new postgrest orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains configuration files for orchestrating Austin Transporta
 
 ## Design
 
-ATD relies on multiple postgREST services. These services are fronted by a single [HAProxy](http://www.haproxy.org/) load balancer, which functiones as a reverse proxy to route requests to each postgREST instance.
+ATD relies on multiple postgREST services. These services are fronted by a single [HAProxy](http://www.haproxy.org/) load balancer, which functions as a reverse proxy to route requests to each postgREST instance.
 
 The root endpoint is available at [http://atd-postgrest.austinmobility.io/](http://atd-postgrest.austinmobility.io/).
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,18 @@ This repository contains configuration files for orchestrating Austin Transporta
 
 ## Table of contents
 
-- [Design](#design)
-- [Services](#services)
-- [Configuration](#configuration)
-- [Get it running](#get-it-running)
+- [atd-postgrest](#atd-postgrest)
+  - [Table of contents](#table-of-contents)
+  - [Design](#design)
+  - [Services](#services)
+  - [Configuration](#configuration)
+    - [Environment variables](#environment-variables)
+    - [Docker](#docker)
+    - [HAProxy](#haproxy)
+    - [`happroxy/config/haproxy.cfg`](#happroxyconfighaproxycfg)
+    - [`happroxy/maps/routes.map`](#happroxymapsroutesmap)
+  - [Get it running](#get-it-running)
+  - [Deployment](#deployment)
 
 ## Design
 
@@ -61,3 +69,9 @@ This filed defines which how an inbound HTTP request's path will be mapped to th
 1. Modify `docker-compose.yaml`, `haproxy.cfg`, and `routes.map` as needed.
 2. Create an environment file in the root directory. Name it `env`.
 3. Start the services: `$ docker-compose --env-file env up -d`
+
+## Deployment
+
+The script `/scripts/docker-keepalive.sh` checks if the HAProxy service is running, and restarts all containers if not. This script is deployed to the prod server's crontab to run every hour.
+
+Any changes to this repository must be manually pulled on the prod server.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains configuration files for orchestrating Austin Transporta
     - [`happroxy/maps/routes.map`](#happroxymapsroutesmap)
   - [Get it running](#get-it-running)
   - [Deployment](#deployment)
+  - [Maintenance](#maintenance)
 
 ## Design
 
@@ -72,8 +73,18 @@ This filed defines which how an inbound HTTP request's path will be mapped to th
 
 ## Deployment
 
+Docker is configured on the production server to restart on boot.
+
 The script `/scripts/docker-keepalive.sh` checks if the HAProxy service is running, and restarts all containers if not. This script is deployed to the prod server's crontab to run every hour.
 
 You can inspect the crontab with `sudo crontab -l`.
 
+## Maintenance
+
 Any changes to this repository must be manually pulled on the prod server.
+
+If you make changes to the schema, permissions, or secrets of any of the running postgREST services, you will need to restart the docker-compose service. 
+
+```
+$ docker-compose --env-file env restart
+```

--- a/README.md
+++ b/README.md
@@ -74,4 +74,6 @@ This filed defines which how an inbound HTTP request's path will be mapped to th
 
 The script `/scripts/docker-keepalive.sh` checks if the HAProxy service is running, and restarts all containers if not. This script is deployed to the prod server's crontab to run every hour.
 
+You can inspect the crontab with `sudo crontab -l`.
+
 Any changes to this repository must be manually pulled on the prod server.

--- a/scripts/docker-keepalive.sh
+++ b/scripts/docker-keepalive.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+if [ ! "$(sudo docker ps | grep atd-postgrest_haproxy_1)" ]; then
+    # container is not running - prune all stopped containers
+    sudo docker container prune --force
+    # start docker-compose
+    sudo docker-compose --file /home/ec2-user/atd-postgrest/docker-compose.yaml --env-file /home/ec2-user/atd-postgrest/env up -d
+fi

--- a/scripts/docker-keepalive.sh
+++ b/scripts/docker-keepalive.sh
@@ -2,6 +2,8 @@
 if [ ! "$(sudo docker ps | grep atd-postgrest_haproxy_1)" ]; then
     # container is not running - prune all stopped containers
     sudo docker container prune --force
+    # stop docker-compose (in case postgrest services are running)
+    sudo docker-compose --file /home/ec2-user/atd-postgrest/docker-compose.yaml --env-file /home/ec2-user/atd-postgrest/env down
     # start docker-compose
     sudo docker-compose --file /home/ec2-user/atd-postgrest/docker-compose.yaml --env-file /home/ec2-user/atd-postgrest/env up -d
 fi


### PR DESCRIPTION
This PR serves as a place to review this new system for managing our slew of postgREST instances. It is currently deployed and active.

I'm looking for feedback on:
- The documentation in this repo
- The documentation in our password manager, which can be found by searching "atd-postgrest".

There is currently no way to fully test this. We do not currently have test instances for any of the DBs. I'm very open to working on that. Each of the various projects that rely on these services will have their own unique constraints around test environment. 

As a minimum test, it would be good if you verify that you can connect to the EC2 bastion host:
1. SSH into the host (see 1Pass)
2. `$ sudo docker ps` to observe the containers.