### PR TITLE
Bump postgrest to v14.1

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - "./haproxy/maps:/etc/haproxy/maps:ro"
 
   postgrest-legacy-scripts:
-    image: postgrest/postgrest:v13.0.7
+    image: postgrest/postgrest:v14.1
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_legacy_scripts
@@ -25,7 +25,7 @@ services:
       PGREST_MAX_ROWS: $PGREST_MAX_ROWS
 
   postgrest-knack-services:
-    image: postgrest/postgrest:v13.0.7
+    image: postgrest/postgrest:v14.1
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_knack_services
@@ -35,7 +35,7 @@ services:
       PGREST_MAX_ROWS: $PGREST_MAX_ROWS
 
   postgrest-parking:
-    image: postgrest/postgrest:v13.0.7
+    image: postgrest/postgrest:v14.1
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_parking
@@ -45,7 +45,7 @@ services:
       PGREST_MAX_ROWS: 10000
 
   postgrest-road-conditions:
-    image: postgrest/postgrest:v13.0.7
+    image: postgrest/postgrest:v14.1
     restart: unless-stopped
     environment:
       #PGRST_LOG_LEVEL: debug
@@ -56,7 +56,7 @@ services:
       PGREST_MAX_ROWS: 10000
 
   postgrest-bond-reporting:
-    image: postgrest/postgrest:v13.0.7
+    image: postgrest/postgrest:v14.1
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_bond_reporting
@@ -66,7 +66,7 @@ services:
       PGREST_MAX_ROWS: 10000
 
   postgrest-public-safety-incidents:
-    image: postgrest/postgrest:v13.0.7
+    image: postgrest/postgrest:v14.1
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_public_safety_incidents


### PR DESCRIPTION
# Intent

This should be a routine update, but I was unable to get the previous month's update in, [seen here](https://github.com/cityofaustin/atd-postgrest/pull/14). I'm closing that PR in deference to this one.

Here's [the docker image](https://hub.docker.com/layers/postgrest/postgrest/v14.1/images/sha256-c2e0f92f1029e8a9584786ad1f818caa79dfcd65cc0232754d3b6143ed6c57d0) this would move us to, and here are [the release](https://github.com/PostgREST/postgrest/releases/tag/v14.1) notes for this software. 

# Testing

Please review the diff, it's only the version changing. 