### PR TITLE
Update postgrest images to version 14.5

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - "./haproxy/maps:/etc/haproxy/maps:ro"
 
   postgrest-legacy-scripts:
-    image: postgrest/postgrest:v14.3
+    image: postgrest/postgrest:v14.5
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_legacy_scripts
@@ -25,7 +25,7 @@ services:
       PGREST_MAX_ROWS: $PGREST_MAX_ROWS
 
   postgrest-knack-services:
-    image: postgrest/postgrest:v14.3
+    image: postgrest/postgrest:v14.5
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_knack_services
@@ -35,7 +35,7 @@ services:
       PGREST_MAX_ROWS: $PGREST_MAX_ROWS
 
   postgrest-parking:
-    image: postgrest/postgrest:v14.3
+    image: postgrest/postgrest:v14.5
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_parking
@@ -45,7 +45,7 @@ services:
       PGREST_MAX_ROWS: 10000
 
   postgrest-road-conditions:
-    image: postgrest/postgrest:v14.3
+    image: postgrest/postgrest:v14.5
     restart: unless-stopped
     environment:
       #PGRST_LOG_LEVEL: debug
@@ -56,7 +56,7 @@ services:
       PGREST_MAX_ROWS: 10000
 
   postgrest-bond-reporting:
-    image: postgrest/postgrest:v14.3
+    image: postgrest/postgrest:v14.5
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_bond_reporting
@@ -66,7 +66,7 @@ services:
       PGREST_MAX_ROWS: 10000
 
   postgrest-public-safety-incidents:
-    image: postgrest/postgrest:v14.3
+    image: postgrest/postgrest:v14.5
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_public_safety_incidents


### PR DESCRIPTION
# Minor version bump for `postgrest`

## Details

We're moving from 14.3 to 14.5. You can read some release notes here: https://github.com/PostgREST/postgrest/releases. 

Here is the image we want to run on docker hub: https://hub.docker.com/layers/postgrest/postgrest/v14.5/images/sha256-bb289d00570b569525e1e22fb77c49cd17c17ca3f41da9ee2b4351a35027551b

## Testing

👀 on the diff should work here, but feel free to spin up the local instance too.