### PR TITLE
Update PostgREST images to version 14.7 in Docker Compose Stack

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - "./haproxy/maps:/etc/haproxy/maps:ro"
 
   postgrest-legacy-scripts:
-    image: postgrest/postgrest:v14.5
+    image: postgrest/postgrest:v14.7
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_legacy_scripts
@@ -25,7 +25,7 @@ services:
       PGREST_MAX_ROWS: $PGREST_MAX_ROWS
 
   postgrest-knack-services:
-    image: postgrest/postgrest:v14.5
+    image: postgrest/postgrest:v14.7
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_knack_services
@@ -35,7 +35,7 @@ services:
       PGREST_MAX_ROWS: $PGREST_MAX_ROWS
 
   postgrest-parking:
-    image: postgrest/postgrest:v14.5
+    image: postgrest/postgrest:v14.7
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_parking
@@ -45,7 +45,7 @@ services:
       PGREST_MAX_ROWS: 10000
 
   postgrest-road-conditions:
-    image: postgrest/postgrest:v14.5
+    image: postgrest/postgrest:v14.7
     restart: unless-stopped
     environment:
       #PGRST_LOG_LEVEL: debug
@@ -56,7 +56,7 @@ services:
       PGREST_MAX_ROWS: 10000
 
   postgrest-bond-reporting:
-    image: postgrest/postgrest:v14.5
+    image: postgrest/postgrest:v14.7
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_bond_reporting
@@ -66,7 +66,7 @@ services:
       PGREST_MAX_ROWS: 10000
 
   postgrest-public-safety-incidents:
-    image: postgrest/postgrest:v14.5
+    image: postgrest/postgrest:v14.7
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_public_safety_incidents


### PR DESCRIPTION
# Bump Postgrest Version to current

## Issue

https://github.com/cityofaustin/atd-data-tech/issues/27119

## Testing

👀 on the code, and verify image exists, [here](https://hub.docker.com/layers/postgrest/postgrest/v14.7/images/sha256-1791139f50b4939d738c5b0009329aa9e9d4be0a960b6b580c4944b16e157b95).

Bonus points if you want to spin up the local instance, but I don't feel that this is required.

## Deployment

On merge, I will deploy to production and restart the services.

---

## 🤖 Summary

This pull request updates the PostgREST Docker images used by several services in the `docker-compose.yaml` file. All affected services are now set to use version `v14.7` of the `postgrest/postgrest` image instead of `v14.5`. This ensures consistency across services and brings in any bug fixes or improvements from the newer PostgREST version.

**Dependency updates:**

* Updated the `postgrest/postgrest` image version from `v14.5` to `v14.7` for the following services in `docker-compose.yaml`:
  - `postgrest-legacy-scripts`
  - `postgrest-knack-services`
  - `postgrest-parking`
  - `postgrest-road-conditions`
  - `postgrest-bond-reporting`
  - `postgrest-public-safety-incidents`

