### PR TITLE
Bump postgrest to 14.11

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - "./haproxy/maps:/etc/haproxy/maps:ro"
 
   postgrest-legacy-scripts:
-    image: postgrest/postgrest:v14.10
+    image: postgrest/postgrest:v14.11
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_legacy_scripts
@@ -25,7 +25,7 @@ services:
       PGREST_MAX_ROWS: $PGREST_MAX_ROWS
 
   postgrest-knack-services:
-    image: postgrest/postgrest:v14.10
+    image: postgrest/postgrest:v14.11
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_knack_services
@@ -35,7 +35,7 @@ services:
       PGREST_MAX_ROWS: $PGREST_MAX_ROWS
 
   postgrest-parking:
-    image: postgrest/postgrest:v14.10
+    image: postgrest/postgrest:v14.11
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_parking
@@ -45,7 +45,7 @@ services:
       PGREST_MAX_ROWS: 10000
 
   postgrest-road-conditions:
-    image: postgrest/postgrest:v14.10
+    image: postgrest/postgrest:v14.11
     restart: unless-stopped
     environment:
       #PGRST_LOG_LEVEL: debug
@@ -56,7 +56,7 @@ services:
       PGREST_MAX_ROWS: 10000
 
   postgrest-bond-reporting:
-    image: postgrest/postgrest:v14.10
+    image: postgrest/postgrest:v14.11
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_bond_reporting
@@ -66,7 +66,7 @@ services:
       PGREST_MAX_ROWS: 10000
 
   postgrest-public-safety-incidents:
-    image: postgrest/postgrest:v14.10
+    image: postgrest/postgrest:v14.11
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_public_safety_incidents


### PR DESCRIPTION
# Bump Postgrest Version to current

## Issue

https://github.com/cityofaustin/atd-data-tech/issues/28024

## Testing

👀 on the code, and verify image exists, [here](https://hub.docker.com/layers/postgrest/postgrest/v14.11/images/sha256-6c73922f8a5849606999a2cb0bcc2a1f0742814aa32895496f4f06f6dddcc497).

Bonus points if you want to spin up the local instance, but I don't feel that this is required.

## Deployment

On merge, I will deploy to production and restart the services. 🏁 
