### PR TITLE
Bump PostgREST images to version 14.16 in Docker Compose stack

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - "./haproxy/maps:/etc/haproxy/maps:ro"
 
   postgrest-legacy-scripts:
-    image: postgrest/postgrest:v14.14
+    image: postgrest/postgrest:v14.16
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_legacy_scripts
@@ -25,7 +25,7 @@ services:
       PGREST_MAX_ROWS: $PGREST_MAX_ROWS
 
   postgrest-knack-services:
-    image: postgrest/postgrest:v14.14
+    image: postgrest/postgrest:v14.16
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_knack_services
@@ -35,7 +35,7 @@ services:
       PGREST_MAX_ROWS: $PGREST_MAX_ROWS
 
   postgrest-parking:
-    image: postgrest/postgrest:v14.14
+    image: postgrest/postgrest:v14.16
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_parking
@@ -45,7 +45,7 @@ services:
       PGREST_MAX_ROWS: 10000
 
   postgrest-road-conditions:
-    image: postgrest/postgrest:v14.14
+    image: postgrest/postgrest:v14.16
     restart: unless-stopped
     environment:
       #PGRST_LOG_LEVEL: debug
@@ -56,7 +56,7 @@ services:
       PGREST_MAX_ROWS: 10000
 
   postgrest-bond-reporting:
-    image: postgrest/postgrest:v14.14
+    image: postgrest/postgrest:v14.16
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_bond_reporting
@@ -66,7 +66,7 @@ services:
       PGREST_MAX_ROWS: 10000
 
   postgrest-public-safety-incidents:
-    image: postgrest/postgrest:v14.14
+    image: postgrest/postgrest:v14.16
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:5432/postgrest_public_safety_incidents


### PR DESCRIPTION
# Bump Postgrest Version to current

## Issue

https://github.com/cityofaustin/atd-data-tech/issues/29293

## Testing

👀 on the code, and verify image exists, [here](https://hub.docker.com/layers/postgrest/postgrest/v14.16/images/sha256-ff0ef3dd967144c14787825f860d47db57b9c078a5b3c0eb2e20ee5d53eb86f3).

Bonus points if you want to spin up the local instance, but I don't feel that this is required.

## Deployment

On merge, I will deploy to production and restart the services. 🏁 
